### PR TITLE
#dooray-공통/1316 angular-gettext-extract-loader를 전체적으로 개선했습니다.

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const _ = require('lodash');
+const Extractor = require('angular-gettext-tools').Extractor;
+const loaderUtils = require("loader-utils");
+
+exports.default = function (source) {
+  const callback = this.async();
+  var loaderOptions = loaderUtils.getOptions(this) || {};
+  const options = _.cloneDeep(loaderOptions);
+  const possibleExtensions = _.keys(options.extensions);
+  const extractor = new Extractor(options);
+
+  extractor.parse(path.relative(this.rootContext || '', this.resourcePath), source);
+
+  this.emitData && this.emitData(this.resourcePath, extractor.strings);
+  callback(null, source);
+}
+
+function extractExtension(request) {
+  return request && request.split('.').pop();
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Rowan Crawford <wombleton@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "angular-gettext-tools": "^2.1.4",
+    "angular-gettext-tools": "github:kbs0327/angular-gettext-tools#master",
     "loader-utils": "1.1.0",
     "lodash": "^3.10.1",
     "pofile": "^1.0.0"


### PR DESCRIPTION
1. thread-loader customize 버전을 사용하면 동작하게 수정
2. loader에서 키를 extract한 후에 plugin에서 1개의 po파일로 병합